### PR TITLE
Updates to allow building and running on Windows

### DIFF
--- a/AMBE2WAV/AMBE2WAV.vcxproj
+++ b/AMBE2WAV/AMBE2WAV.vcxproj
@@ -23,7 +23,7 @@
     <ProjectGuid>{409738EE-5065-4E9C-8C8A-EA47760176BD}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>AMBE2WAV</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/Common/Common.vcxproj
+++ b/Common/Common.vcxproj
@@ -22,7 +22,7 @@
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{65F54051-CF86-4B42-A112-C37CE8248C91}</ProjectGuid>
     <RootNamespace>Common</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/Common/WAVFileReader.h
+++ b/Common/WAVFileReader.h
@@ -22,11 +22,13 @@
 #include <string>
 
 #include <cstdio>
-#include <sndfile.h>
+
 
 #if defined(_WIN32) || defined(_WIN64)
 #include <windows.h>
 #include <mmsystem.h>
+#else
+#include <sndfile.h>
 #endif
 
 enum WAVFORMAT {

--- a/Common/WAVFileWriter.h
+++ b/Common/WAVFileWriter.h
@@ -22,11 +22,12 @@
 #include <string>
 
 #include <cstdio>
-#include <sndfile.h>
 
 #if defined(_WIN32) || defined(_WIN64)
 #include <windows.h>
 #include <mmsystem.h>
+#else
+#include <sndfile.h>
 #endif
 
 class CWAVFileWriter {

--- a/README.md
+++ b/README.md
@@ -33,5 +33,13 @@ where
 
 [-d] print debugging information
 
+
+## Building
+
+The repo https://github.com/g4klx/imbe_vocoder needs to be cloned and placed at the same level in the file structure as the folder for this repository
+
 On Linux these programs need access to the libsndfile library for compiling and running.
+
+
+
 

--- a/WAV2AMBE/WAV2AMBE.vcxproj
+++ b/WAV2AMBE/WAV2AMBE.vcxproj
@@ -23,7 +23,7 @@
     <ProjectGuid>{4CDA3CDE-A974-4D11-B587-FF4D5C6C4914}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>WAV2AMBE</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">


### PR DESCRIPTION
Fixed problem where sndfile.h was referenced by unavailable and unused on Windows
Fixed problem of old Windows SDK version needing to be installed on target machines
Updated Readme to explain how the IMBE_Vocoder repo is needed in order to build this repo